### PR TITLE
Fix token refresh race condition

### DIFF
--- a/auth/token.go
+++ b/auth/token.go
@@ -157,6 +157,9 @@ func GetToken(ctx context.Context, params TokenParams, client *http.Client) (*To
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	var result oauth2Response
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -41,9 +42,10 @@ func (c *HttpClient) Do(req *http.Request) (*http.Response, error) {
 	// If the token has expired, get a new one.
 	if c.clock.Now().After(token.ExpiresAt) {
 		token, err := auth.GetToken(
-			c.AuthenticatedContext,
+			context.Background(),
 			c.AuthenticatedContext.GetTokenParams(),
-			nil)
+			c.Client,
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fix for a potential race condition in the client's token refresh logic.

Also includes a couple of minor improvements:
- Reuse the embedded client for `GetToken` requests
- Add missing error check

### Context

- `AuthenticatedContext` wraps a `context.Context` (and stuffs a token in it)
- Making requests with the client 'refreshes' the token if it's expired - as in https://github.com/fragment-dev/fragment-go/blob/dev/client/client.go#L41-L52
- The call to `SetToken` on line 51 overwrites the `Context`
- That same context is used for the HTTP request just [a few lines prior](https://github.com/fragment-dev/fragment-go/blob/dev/client/client.go#L44), and Go's `net/http` library may well still be reading from the context by the time we overwrite it (a network roundtrip involves a few goroutines behind the scenes)

That leads to a race condition - example report included below:

<details>
<summary>Example race report from testing against a `httpserver`</summary>

```
==================
WARNING: DATA RACE
Write at 0x00c00009c710 by goroutine 7:
  github.com/fragment-dev/fragment-go/auth.(*authenticatedContext).SetToken()
      /Users/kieron/go/src/github.com/fragment-dev/fragment-go/auth/token.go:95 +0x6c
  github.com/fragment-dev/fragment-go/client.(*HttpClient).Do()
      /Users/kieron/go/src/github.com/fragment-dev/fragment-go/client/client.go:52 +0xec
  github.com/fragment-dev/fragment-go/client.TestTokenRefresh()
      /Users/kieron/go/src/github.com/fragment-dev/fragment-go/client/client_test.go:92 +0x5b4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1851 +0x40

Previous read at 0x00c00009c710 by goroutine 11:
  github.com/fragment-dev/fragment-go/auth.(*authenticatedContext).Done()
      <autogenerated>:1 +0x34
  context.parentCancelCtx()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/context/context.go:377 +0x34
  context.removeChild()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/context/context.go:398 +0x74
  context.(*cancelCtx).cancel()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/context/context.go:568 +0x27c
  context.WithCancelCause.func1()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/context/context.go:270 +0x5c
  net/http.(*Transport).prepareTransportCancel.func1()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/net/http/transport.go:921 +0x54
  net/http.(*persistConn).readLoop()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/net/http/transport.go:2412 +0x109c
  net/http.(*Transport).dialConn.gowrap2()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/net/http/transport.go:1944 +0x34

Goroutine 7 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:47 +0x110

Goroutine 11 (running) created at:
  net/http.(*Transport).dialConn()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/net/http/transport.go:1944 +0x2188
  net/http.(*Transport).dialConnFor()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/net/http/transport.go:1615 +0xb8
  net/http.(*Transport).startDialConnForLocked.func1()
      /opt/homebrew/Cellar/go/1.24.4/libexec/src/net/http/transport.go:1597 +0x38
==================
```
</details>

### Fix

To fix it, we can use a fresh context when getting making the request to `GetToken` - reducing the risk that the context can be read from at the same time as it gets overwritten.