### PR TITLE
Add /v3 suffix to module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This library requires Go 1.20+.
 
 ``` shell
-go get -u github.com/fragment-dev/fragment-go
+go get -u github.com/fragment-dev/fragment-go/v3
 ```
 
 ## Usage
@@ -20,8 +20,8 @@ import (
   "fmt"
   "os"
   
-  "github.com/fragment-dev/fragment-go/client"
-  "github.com/fragment-dev/fragment-go/queries"
+  "github.com/fragment-dev/fragment-go/v3/client"
+  "github.com/fragment-dev/fragment-go/v3/queries"
 )
 
 func main() {
@@ -60,7 +60,7 @@ We appreciate feedback; please open an [issue](https://github.com/fragment-dev/f
 While the SDK comes with predefined GraphQL queries, you may want to customize these queries for your product. In order to do that, run:
 
 ``` shell
-go run github.com/fragment-dev/fragment-go \
+go run github.com/fragment-dev/fragment-go/v3 \
   --input <path-to-your-graphql-queries-file.graphql>
   --output <path-to-the-output.go>
   --package <package-name>
@@ -87,7 +87,7 @@ query GetLatestSchema($key: SafeString!) {
 Run the SDK codegen to generate the code for your GraphQL query.
 
 ``` shell
-go run github.com/fragment-dev/fragment-go \
+go run github.com/fragment-dev/fragment-go/v3 \
   --input queries.graphql
   --output queries.go
   --package main
@@ -131,7 +131,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fragment-dev/fragment-go/queries"
+	"github.com/fragment-dev/fragment-go/v3/queries"
 )
 
 type UserFundsAccountParameters struct {
@@ -181,7 +181,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fragment-dev/fragment-go/queries"
+	"github.com/fragment-dev/fragment-go/v3/queries"
 )
 
 func main() {
@@ -212,7 +212,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fragment-dev/fragment-go/queries"
+	"github.com/fragment-dev/fragment-go/v3/queries"
 )
 
 func main() {
@@ -251,7 +251,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fragment-dev/fragment-go/queries"
+	"github.com/fragment-dev/fragment-go/v3/queries"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Fragment](https://fragment.dev) is the Ledger API for engineers that move money. Stop wrangling payment tables, debugging balance errors, and hacking together data pipelines. Start shipping the features that make a difference.
 
-> If you're upgrading from an earlier version, the module import path has changed to `github.com/fragment-dev/fragment-go/v3`. Update your imports to use `/v3` to get the latest version. See the [Upgrading SDK Versions](#upgrading-sdk-versions) section for details.
+> We've upgraded the module import path to `github.com/fragment-dev/fragment-go/v3`. The `github.com/fragment-dev/fragment-go` module is no longer supported. Update your imports to use `/v3` to get the latest version. See the [Upgrading SDK Versions](#upgrading-sdk-versions) section for details.
 
 ## Installation
 
@@ -271,6 +271,9 @@ func main() {
 ```
 
 ## Upgrading SDK Versions
+### Changes in v3.1.0
+ - Module import path updated to `/v3`: Update all imports from `github.com/fragment-dev/fragment-go` to `github.com/fragment-dev/fragment-go/v3` 
+
 ### Changes from v2.0.0 to v3.0.0
 
 - Removed `AuthenticatedContext` and replaced it with `client.NewClient()`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Fragment](https://fragment.dev) is the Ledger API for engineers that move money. Stop wrangling payment tables, debugging balance errors, and hacking together data pipelines. Start shipping the features that make a difference.
 
+> If you're upgrading from an earlier version, the module import path has changed to `github.com/fragment-dev/fragment-go/v3`. Update your imports to use `/v3` to get the latest version. See the [Upgrading SDK Versions](#upgrading-sdk-versions) section for details.
+
 ## Installation
 
 This library requires Go 1.20+.

--- a/example/main.go
+++ b/example/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fragment-dev/fragment-go/client"
-	"github.com/fragment-dev/fragment-go/queries"
+	"github.com/fragment-dev/fragment-go/v3/client"
+	"github.com/fragment-dev/fragment-go/v3/queries"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fragment-dev/fragment-go
+module github.com/fragment-dev/fragment-go/v3
 
 go 1.22.5
 


### PR DESCRIPTION
Since we're now on v3, we needed to update the module path so users can correctly import SDK. 

Fixes FRA-6109